### PR TITLE
slides.html - copy-paste error corrected

### DIFF
--- a/L2/slides.html
+++ b/L2/slides.html
@@ -111,8 +111,10 @@ addS x y = mapS (\t -> sample x t + sample y t) timeS
 
 * Shallow embedding
     * Represent elements by their semantics (what observations they support)
-* Deep embedding
     * Constructor functions and combinators do most of the work, run functions for free
+* Deep embedding
+    * Represent elements by how they are constructed
+    * Most of the work done by the run functions, constructor functions and combinators for free
 * Or something in-between
 
 ---


### PR DESCRIPTION
The bullet point under **Deep embedding** actually belongs to **Shallow embedding**.

The reason: 
**Deep embedding** section of the slide 5 slide from http://www.cse.chalmers.se/edu/course/afp/lectures/lecture2/lecture2.pdf was not copied, **Shallow embedding** was copied and split into 2 parts in the HTML file. 
